### PR TITLE
Fix: Stacking zip sizes

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -78,7 +78,7 @@ build_macos(){
 
         # Setup final archives
         mv "love.app" "${bm_target}.app"
-        zip -ry "${bm_target}.zip" "${bm_target}.app" -x "${INPUT_RESULT_DIR}/*"
+        zip -ry "${bm_target}.zip" "${bm_target}.app"
     )
     mv "${bm_build_dir}/${bm_target}.zip" "${RESULT_DIR}"
     echo "::set-output name=macos-filename::${INPUT_RESULT_DIR}/${bm_target}.zip"
@@ -110,7 +110,7 @@ build_windows(){
         rm "${bw_target}/readme.txt"
 
         # Setup final archive
-        zip -ry "${bw_target}.zip" "${bw_target}" -x "${INPUT_RESULT_DIR}/*"
+        zip -ry "${bw_target}.zip" "${bw_target}"
     )
     mv "${bw_build_dir}/${bw_target}.zip" "${RESULT_DIR}"/
     echo "::set-output name=${bw_arch}-filename::${INPUT_RESULT_DIR}/${bw_target}.zip"

--- a/build.sh
+++ b/build.sh
@@ -48,9 +48,10 @@ build_lovefile(){
             cat /love-build/module_loader.lua main.lua > new_main.lua
             mv new_main.lua main.lua
         fi
+        echo "building lovefile"
         echo $PWD
         ls -lah
-        zip -r "application.love" ./* -x '*.git*' "${INPUT_RESULT_DIR}/\*"
+        zip -r "application.love" ./* -x '*.git*' "${INPUT_RESULT_DIR}/*"
     )
     mv "${blf_build_dir}/application.love" "${blf_target}"
     rm -rf "${blf_build_dir}"
@@ -80,7 +81,7 @@ build_macos(){
 
         # Setup final archives
         mv "love.app" "${bm_target}.app"
-        zip -ry "${bm_target}.zip" "${bm_target}.app" -x "${INPUT_RESULT_DIR}/\*"
+        zip -ry "${bm_target}.zip" "${bm_target}.app" -x "${INPUT_RESULT_DIR}/*"
     )
     mv "${bm_build_dir}/${bm_target}.zip" "${RESULT_DIR}"
     echo "::set-output name=macos-filename::${INPUT_RESULT_DIR}/${bm_target}.zip"
@@ -110,9 +111,13 @@ build_windows(){
         rm "${bw_target}/love.ico"
         rm "${bw_target}/changes.txt"
         rm "${bw_target}/readme.txt"
+        
+        echo "building windows"
+        echo $PWD
+        ls -lah
 
         # Setup final archive
-        zip -ry "${bw_target}.zip" "${bw_target}" -x "${INPUT_RESULT_DIR}/\*"
+        zip -ry "${bw_target}.zip" "${bw_target}" -x "${INPUT_RESULT_DIR}/*"
     )
     mv "${bw_build_dir}/${bw_target}.zip" "${RESULT_DIR}"/
     echo "::set-output name=${bw_arch}-filename::${INPUT_RESULT_DIR}/${bw_target}.zip"

--- a/build.sh
+++ b/build.sh
@@ -48,7 +48,7 @@ build_lovefile(){
             cat /love-build/module_loader.lua main.lua > new_main.lua
             mv new_main.lua main.lua
         fi
-        zip -r "application.love" ./* -x '*.git*' "${RESULT_DIR}/\*"
+        zip -r "application.love" ./* -x '*.git*' "${INPUT_RESULT_DIR}/\*"
     )
     mv "${blf_build_dir}/application.love" "${blf_target}"
     rm -rf "${blf_build_dir}"
@@ -78,7 +78,7 @@ build_macos(){
 
         # Setup final archives
         mv "love.app" "${bm_target}.app"
-        zip -ry "${bm_target}.zip" "${bm_target}.app" -x "${RESULT_DIR}/\*"
+        zip -ry "${bm_target}.zip" "${bm_target}.app" -x "${INPUT_RESULT_DIR}/\*"
     )
     mv "${bm_build_dir}/${bm_target}.zip" "${RESULT_DIR}"
     echo "::set-output name=macos-filename::${INPUT_RESULT_DIR}/${bm_target}.zip"
@@ -110,7 +110,7 @@ build_windows(){
         rm "${bw_target}/readme.txt"
 
         # Setup final archive
-        zip -ry "${bw_target}.zip" "${bw_target}" -x "${RESULT_DIR}/\*"
+        zip -ry "${bw_target}.zip" "${bw_target}" -x "${INPUT_RESULT_DIR}/\*"
     )
     mv "${bw_build_dir}/${bw_target}.zip" "${RESULT_DIR}"/
     echo "::set-output name=${bw_arch}-filename::${INPUT_RESULT_DIR}/${bw_target}.zip"

--- a/build.sh
+++ b/build.sh
@@ -48,6 +48,8 @@ build_lovefile(){
             cat /love-build/module_loader.lua main.lua > new_main.lua
             mv new_main.lua main.lua
         fi
+        echo $PWD
+        ls -lah
         zip -r "application.love" ./* -x '*.git*' "${INPUT_RESULT_DIR}/\*"
     )
     mv "${blf_build_dir}/application.love" "${blf_target}"
@@ -127,6 +129,7 @@ main() {
     echo "---------------------------"
     echo "Source directory: ${INPUT_SOURCE_DIR}"
     echo "Result directory: ${INPUT_RESULT_DIR}"
+    echo "GITHUB_WORKSPACE: ${GITHUB_WORKSPACE}"
     echo "---------------------------"
 
     # Append workspace dir to relevant paths
@@ -134,6 +137,7 @@ main() {
     RESULT_DIR=${GITHUB_WORKSPACE}/${INPUT_RESULT_DIR}
     
     # Make results directory if it does not exist
+    echo "current dir: ${PWD}"
     mkdir -p "${RESULT_DIR}"
     
     ### LOVE build ####################################################

--- a/build.sh
+++ b/build.sh
@@ -10,7 +10,7 @@ check_environment() {
     : "${INPUT_APP_NAME:?'Error: application name unset'}"
     : "${INPUT_LOVE_VERSION:?'Error: love version unset'}"
     # Check for presence of main.lua
-    if [ ! -f "${INPUT_SOURCE_DIR}/main.lua" ]; then
+    if [ ! -f "${SOURCE_DIR}/main.lua" ]; then
         echo "Error: Cannot find main.lua in the specified source directory"
         exit 1
     fi
@@ -48,9 +48,6 @@ build_lovefile(){
             cat /love-build/module_loader.lua main.lua > new_main.lua
             mv new_main.lua main.lua
         fi
-        echo "building lovefile"
-        echo $PWD
-        ls -lah
         zip -r "application.love" ./* -x '*.git*' "${INPUT_RESULT_DIR}/*"
     )
     mv "${blf_build_dir}/application.love" "${blf_target}"
@@ -111,10 +108,6 @@ build_windows(){
         rm "${bw_target}/love.ico"
         rm "${bw_target}/changes.txt"
         rm "${bw_target}/readme.txt"
-        
-        echo "building windows"
-        echo $PWD
-        ls -lah
 
         # Setup final archive
         zip -ry "${bw_target}.zip" "${bw_target}" -x "${INPUT_RESULT_DIR}/*"
@@ -125,8 +118,6 @@ build_windows(){
 }
 
 main() {
-    
-    check_environment    
 
     echo "-- LOVE build parameters --"
     echo "App name: ${INPUT_APP_NAME}"
@@ -134,15 +125,15 @@ main() {
     echo "---------------------------"
     echo "Source directory: ${INPUT_SOURCE_DIR}"
     echo "Result directory: ${INPUT_RESULT_DIR}"
-    echo "GITHUB_WORKSPACE: ${GITHUB_WORKSPACE}"
     echo "---------------------------"
 
     # Append workspace dir to relevant paths
     SOURCE_DIR=${GITHUB_WORKSPACE}/${INPUT_SOURCE_DIR}
     RESULT_DIR=${GITHUB_WORKSPACE}/${INPUT_RESULT_DIR}
     
+    check_environment
+    
     # Make results directory if it does not exist
-    echo "current dir: ${PWD}"
     mkdir -p "${RESULT_DIR}"
     
     ### LOVE build ####################################################

--- a/build.sh
+++ b/build.sh
@@ -48,7 +48,7 @@ build_lovefile(){
             cat /love-build/module_loader.lua main.lua > new_main.lua
             mv new_main.lua main.lua
         fi
-        zip -r "application.love" ./* -x '*.git*'
+        zip -r "application.love" ./* -x '*.git*' "${RESULT_DIR}/\*"
     )
     mv "${blf_build_dir}/application.love" "${blf_target}"
     rm -rf "${blf_build_dir}"
@@ -78,7 +78,7 @@ build_macos(){
 
         # Setup final archives
         mv "love.app" "${bm_target}.app"
-        zip -ry "${bm_target}.zip" "${bm_target}.app" 
+        zip -ry "${bm_target}.zip" "${bm_target}.app" -x "${RESULT_DIR}/\*"
     )
     mv "${bm_build_dir}/${bm_target}.zip" "${RESULT_DIR}"
     echo "::set-output name=macos-filename::${INPUT_RESULT_DIR}/${bm_target}.zip"
@@ -110,7 +110,7 @@ build_windows(){
         rm "${bw_target}/readme.txt"
 
         # Setup final archive
-        zip -ry "${bw_target}.zip" "${bw_target}"
+        zip -ry "${bw_target}.zip" "${bw_target}" -x "${RESULT_DIR}/\*"
     )
     mv "${bw_build_dir}/${bw_target}.zip" "${RESULT_DIR}"/
     echo "::set-output name=${bw_arch}-filename::${INPUT_RESULT_DIR}/${bw_target}.zip"


### PR DESCRIPTION
Fixes #10 

### Changes
* When zipping the files, the `${INPUT_RESULT_DIR}` and all its content is ignored
* The check for a `main.lua` file is now done in the source directory under the GitHub workspace, i.e. `${SOURCE_DIR}`

### Explanation of the fix
For a repository with `main.lua` at its root, one could use the defaults for `${INPUT_SOURCE_DIR}`, `${INPUT_RESULT_DIR}` that are `./`, `release` respectively. This results in the `release` directory being created within the main codebase under `./release`. Hence, when creating the love file the previously built files within `release` also get zipped.

P.S. Feel free to squash the commits as my commit history is a bit messy.