### PR TITLE
Fix for older versions of love2d

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -5,13 +5,12 @@ on:
   push:
     branches: [ dev ]
 jobs:
-  version-matrix:
-      strategy:
-        matrix:
-          love_version: ['11.4', '11.3', '11.2', '0.10.2', '0.9.2', '0.8.0', '0.7.2']
   # Build the Hello World test application
   build-hello_world:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        love_version: ['11.4', '11.3', '11.2', '0.10.2', '0.9.2', '0.8.0', '0.7.2']
     steps:
     - uses: actions/checkout@v2
     - uses: nhartland/love-build@dev
@@ -40,6 +39,9 @@ jobs:
   # Build the Game of Life test application
   build-game_of_life:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        love_version: ['11.4', '11.3', '11.2', '0.10.2', '0.9.2', '0.8.0', '0.7.2']
     steps:
     - uses: actions/checkout@v2
     - uses: nhartland/love-build@dev

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -9,6 +9,7 @@ jobs:
   build-hello_world:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         love_version: ['11.4', '11.3', '11.2', '0.10.2', '0.9.2', '0.8.0', '0.7.2']
     steps:
@@ -40,6 +41,7 @@ jobs:
   build-game_of_life:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         love_version: ['11.4', '11.3', '11.2', '0.10.2', '0.9.2', '0.8.0', '0.7.2']
     steps:

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -5,6 +5,10 @@ on:
   push:
     branches: [ dev ]
 jobs:
+  version-matrix:
+      strategy:
+        matrix:
+          love_version: ['11.4', '11.3', '11.2', '0.10.2', '0.9.2', '0.8.0', '0.7.2']
   # Build the Hello World test application
   build-hello_world:
     runs-on: ubuntu-latest
@@ -14,7 +18,7 @@ jobs:
       id: love-build
       with:
         app_name: 'hello_world'
-        love_version: '11.3'
+        love_version: ${{ matrix.love_version }}
         source_dir: 'tests/hello_world'
     # Upload the resulting artifacts
     - uses: actions/upload-artifact@v1
@@ -42,7 +46,7 @@ jobs:
       id: love-build
       with:
         app_name: 'game_of_life'
-        love_version: '11.3'
+        love_version: ${{ matrix.love_version }}
         source_dir: 'tests/game_of_life'
         dependencies: 'tests/game_of_life/dependencies-1-1.rockspec'
     # Upload the resulting artifacts

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -43,7 +43,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        love_version: ['11.4', '11.3', '11.2', '0.10.2', '0.9.2', '0.8.0', '0.7.2']
+        love_version: ['11.4', '11.3', '11.2', '0.10.2', '0.9.2', '0.8.0']
     steps:
     - uses: actions/checkout@v2
     - uses: nhartland/love-build@dev

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        love_version: ['11.4', '11.3', '11.2', '0.10.2', '0.9.2', '0.8.0', '0.7.2']
+        love_version: ['11.4', '11.3', '11.2', '0.10.2', '0.9.2', '0.8.0']
     steps:
     - uses: actions/checkout@v2
     - uses: nhartland/love-build@dev

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -8,13 +8,17 @@ jobs:
   # Build the Hello World test application
   build-hello_world:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        love_version: ['11.4', '11.3', '11.2', '0.10.2', '0.9.2', '0.8.0']
     steps:
     - uses: actions/checkout@v2
     - uses: nhartland/love-build@master
       id: love-build
       with:
         app_name: 'hello_world'
-        love_version: '11.3'
+        love_version: ${{ matrix.love_version }}
         source_dir: 'tests/hello_world'
     # Upload the resulting artifacts
     - uses: actions/upload-artifact@v1
@@ -42,7 +46,7 @@ jobs:
       id: love-build
       with:
         app_name: 'game_of_life'
-        love_version: '11.3'
+        love_version: ${{ matrix.love_version }}
         source_dir: 'tests/game_of_life'
         dependencies: 'tests/game_of_life/dependencies-1-1.rockspec'
     # Upload the resulting artifacts

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -40,6 +40,10 @@ jobs:
   # Build the Game of Life test application
   build-game_of_life:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        love_version: ['11.4', '11.3', '11.2', '0.10.2', '0.9.2', '0.8.0']
     steps:
     - uses: actions/checkout@v2
     - uses: nhartland/love-build@master

--- a/README.md
+++ b/README.md
@@ -151,3 +151,6 @@ applications running, for example icons are not yet configurable.
 Furthermore the macOS build is unverified by Apple and therefore will need
 to be manually opened in the Security and Preferences pane at least for the
 first time it is run.
+
+Only projects based on LÖVE version 0.8.0 or greater are supported. Before
+0.8.0, , no win64 binaries were provided.

--- a/build.sh
+++ b/build.sh
@@ -93,10 +93,10 @@ build_windows(){
         cd "${bw_build_dir}" 
         # Download love for macos
         get_love_binaries "${bw_arch}"
-        love_dir=$(find . -type d -regex '.*/love-.*' | head -n1)
-        echo "$love_dir"
 
-        mv "love-${INPUT_LOVE_VERSION}-${bw_arch}" "${INPUT_APP_NAME}_${bw_arch}"
+        # Get unpacked directory name (can vary a bit, e.g 11.4, 11.2.0) and rename
+        love_dir=$(find . -type d -regex ".*/love-.*-${bw_arch}" | head -n1)
+        mv "${love_dir}" "${INPUT_APP_NAME}_${bw_arch}"
 
         # Copy data
         cat "${bw_target}/love.exe" "application.love" > "${bw_target}/${INPUT_APP_NAME}.exe"

--- a/build.sh
+++ b/build.sh
@@ -63,8 +63,8 @@ build_macos(){
         # Change to build dir (subshell to preserve cwd)
         cd "${bm_build_dir}" 
         # Download love for macos
-        # Older (pre v11) labelled this as "macos-x64"
-        get_love_binaries "macos" || get_love_binaries "macos-x64"
+        # Older (pre v11) labelled this as "macosx-x64"
+        get_love_binaries "macos" || get_love_binaries "macosx-x64"
 
         # Copy Data
         cp "application.love" "love.app/Contents/Resources/"

--- a/build.sh
+++ b/build.sh
@@ -145,12 +145,12 @@ main() {
     
     build_macos
     { 
-        build_windows win32 win32 
-        build_windows win64 win64 
+        build_windows "win32" "win32" 
+        build_windows "win64" "win64" 
     } || 
     { 
-        build_windows win32 win-x86 
-        build_windows win64 win-x64 
+        build_windows "win32" "win-x86" 
+        build_windows "win64" "win-x64" 
     }
 
 }

--- a/build.sh
+++ b/build.sh
@@ -143,11 +143,11 @@ main() {
     
     ### macOS/win builds ##############################################
     
-    build_macos
-    { 
-        build_windows "win32" "win32" 
-        build_windows "win64" "win64" 
-    } || 
+    #build_macos
+    #{ 
+    #    build_windows "win32" "win32" 
+    #    build_windows "win64" "win64" 
+    #} || 
     { 
         build_windows "win32" "win-x86" 
         build_windows "win64" "win-x64" 

--- a/build.sh
+++ b/build.sh
@@ -145,15 +145,15 @@ main() {
     
     build_macos
     { 
-        build_windows "win32" "win32" 
-        build_windows "win64" "win64" 
+        build_windows "win32" "win32";
+        build_windows "win64" "win64";
     } || 
     { 
-        build_windows "win32" "win-x86" 
-        build_windows "win64" "win-x64" 
+        build_windows "win32" "win-x86";
+        build_windows "win64" "win-x64"; 
     } || 
     {
-        exit 1 
+        exit 1;
     }
 
 }

--- a/build.sh
+++ b/build.sh
@@ -93,6 +93,8 @@ build_windows(){
         cd "${bw_build_dir}" 
         # Download love for macos
         get_love_binaries "${bw_arch}"
+        love_dir=$(find . -type d -regex '.*/love-.*' | head -n1)
+        echo "$love_dir"
 
         mv "love-${INPUT_LOVE_VERSION}-${bw_arch}" "${INPUT_APP_NAME}_${bw_arch}"
 

--- a/build.sh
+++ b/build.sh
@@ -151,6 +151,9 @@ main() {
     { 
         build_windows "win32" "win-x86" 
         build_windows "win64" "win-x64" 
+    } || 
+    {
+        exit 1 
     }
 
 }

--- a/build.sh
+++ b/build.sh
@@ -43,7 +43,7 @@ build_lovefile(){
         if [ -n "${INPUT_DEPENDENCIES}" ]; then
             depsfile="${GITHUB_WORKSPACE}/${INPUT_DEPENDENCIES}"
             # Build the dependencies into a local luarocks tree
-            luarocks make "${depsfile}" --lua-version=5.1 --tree lb_modules 
+            luarocks make "${depsfile}" --deps-mode one --lua-version=5.1 --tree lb_modules 
             # Add custom require paths
             cat /love-build/module_loader.lua main.lua > new_main.lua
             mv new_main.lua main.lua

--- a/build.sh
+++ b/build.sh
@@ -85,7 +85,8 @@ build_macos(){
 # Exports a zipped win32 application to the result directory.
 # Takes the architecure as an argument (win32/win64)
 build_windows(){
-    bw_arch=$1
+    bw_label=$1
+    bw_arch=$2
     bw_target="${INPUT_APP_NAME}_${bw_arch}"
     bw_build_dir=$(mktemp -d -t love-build-XXXXXX)
     build_lovefile "${bw_build_dir}/application.love"
@@ -112,7 +113,7 @@ build_windows(){
         zip -ry "${bw_target}.zip" "${bw_target}"
     )
     mv "${bw_build_dir}/${bw_target}.zip" "${RESULT_DIR}"/
-    echo "::set-output name=${bw_arch}-filename::${INPUT_RESULT_DIR}/${bw_target}.zip"
+    echo "::set-output name=${bw_label}-filename::${INPUT_RESULT_DIR}/${bw_target}.zip"
     rm -rf "${bw_build_dir}"
 }
 
@@ -143,8 +144,8 @@ main() {
     ### macOS/win builds ##############################################
     
     build_macos
-    build_windows win32 || build_windows win-x86
-    build_windows win64 || build_windows win-x64
+    build_windows win32 win32 || build_windows win32 win-x86
+    build_windows win64 win64 || build_windows win64 win-x64
 
 }
 

--- a/build.sh
+++ b/build.sh
@@ -87,7 +87,7 @@ build_macos(){
 build_windows(){
     bw_label=$1
     bw_arch=$2
-    bw_target="${INPUT_APP_NAME}_${bw_arch}"
+    bw_target="${INPUT_APP_NAME}_${bw_label}"
     bw_build_dir=$(mktemp -d -t love-build-XXXXXX)
     build_lovefile "${bw_build_dir}/application.love"
     (
@@ -98,7 +98,7 @@ build_windows(){
 
         # Get unpacked directory name (can vary a bit, e.g 11.4, 11.2.0) and rename
         love_dir=$(find . -type d -regex ".*/love-.*-${bw_arch}" | head -n1)
-        mv "${love_dir}" "${INPUT_APP_NAME}_${bw_arch}"
+        mv "${love_dir}" "${bw_target}"
 
         # Copy data
         cat "${bw_target}/love.exe" "application.love" > "${bw_target}/${INPUT_APP_NAME}.exe"

--- a/build.sh
+++ b/build.sh
@@ -144,8 +144,14 @@ main() {
     ### macOS/win builds ##############################################
     
     build_macos
-    build_windows win32 win32 || build_windows win32 win-x86
-    build_windows win64 win64 || build_windows win64 win-x64
+    { 
+        build_windows win32 win32 
+        build_windows win64 win64 
+    } || 
+    { 
+        build_windows win32 win-x86 
+        build_windows win64 win-x64 
+    }
 
 }
 

--- a/build.sh
+++ b/build.sh
@@ -63,8 +63,8 @@ build_macos(){
         # Change to build dir (subshell to preserve cwd)
         cd "${bm_build_dir}" 
         # Download love for macos
-        # Older (pre v11) labelled this as "macosx-x64"
-        get_love_binaries "macos" || get_love_binaries "macosx-x64"
+        # Older (pre v11) labelled this as "macosx-x64" or "macosx-ub"
+        get_love_binaries "macos" || get_love_binaries "macosx-x64" || get_love_binaries "macosx-ub"
 
         # Copy Data
         cp "application.love" "love.app/Contents/Resources/"

--- a/build.sh
+++ b/build.sh
@@ -143,11 +143,11 @@ main() {
     
     ### macOS/win builds ##############################################
     
-    #build_macos
-    #{ 
-    #    build_windows "win32" "win32" 
-    #    build_windows "win64" "win64" 
-    #} || 
+    build_macos
+    { 
+        build_windows "win32" "win32" 
+        build_windows "win64" "win64" 
+    } || 
     { 
         build_windows "win32" "win-x86" 
         build_windows "win64" "win-x64" 

--- a/build.sh
+++ b/build.sh
@@ -105,7 +105,7 @@ build_windows(){
         esac
 
         # Get unpacked directory name (can vary a bit, e.g 11.4, 11.2.0) and rename
-        love_dir=$(find . -type d -regex ".*/love-.*-win.*}" | head -n1)
+        love_dir=$(find . -type d -regex ".*/love-.*}" | head -n1)
         mv "${love_dir}" "${bw_target}"
 
         # Copy data

--- a/build.sh
+++ b/build.sh
@@ -104,7 +104,7 @@ build_windows(){
         cat "${bw_target}/love.exe" "application.love" > "${bw_target}/${INPUT_APP_NAME}.exe"
         # Delete unneeded files
         rm "${bw_target}/love.exe"
-        rm "${bw_target}/lovec.exe"
+        rm "${bw_target}/lovec.exe" || true
         rm "${bw_target}/love.ico"
         rm "${bw_target}/changes.txt"
         rm "${bw_target}/readme.txt"

--- a/build.sh
+++ b/build.sh
@@ -63,7 +63,8 @@ build_macos(){
         # Change to build dir (subshell to preserve cwd)
         cd "${bm_build_dir}" 
         # Download love for macos
-        get_love_binaries "macos"
+        # Older (pre v11) labelled this as "macos-x64"
+        get_love_binaries "macos" || get_love_binaries "macos-x64"
 
         # Copy Data
         cp "application.love" "love.app/Contents/Resources/"

--- a/build.sh
+++ b/build.sh
@@ -143,8 +143,8 @@ main() {
     ### macOS/win builds ##############################################
     
     build_macos
-    build_windows win32
-    build_windows win64
+    build_windows win32 || build_windows win-x86
+    build_windows win64 || build_windows win-x64
 
 }
 

--- a/build.sh
+++ b/build.sh
@@ -105,7 +105,7 @@ build_windows(){
         esac
 
         # Get unpacked directory name (can vary a bit, e.g 11.4, 11.2.0) and rename
-        love_dir=$(find . -type d -regex ".*/love-.*}" | head -n1)
+        love_dir=$(find . -type d -regex ".*/love-.*" | head -n1)
         mv "${love_dir}" "${bw_target}"
 
         # Copy data

--- a/build.sh
+++ b/build.sh
@@ -105,9 +105,9 @@ build_windows(){
         # Delete unneeded files
         rm "${bw_target}/love.exe"
         rm "${bw_target}/lovec.exe" || true
-        rm "${bw_target}/love.ico"
-        rm "${bw_target}/changes.txt"
-        rm "${bw_target}/readme.txt"
+        rm "${bw_target}/love.ico" || true
+        rm "${bw_target}/changes.txt" || true
+        rm "${bw_target}/readme.txt" || true
 
         # Setup final archive
         zip -ry "${bw_target}.zip" "${bw_target}"


### PR DESCRIPTION
Fixes #12 

Some older versions of love2d didn't follow the same path structure as newer versions, this should fix that!
Additionally we've added a few extra tests to verify that the builds work accross love2d versions.