### PR TITLE
Use actions/checkout@v3

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         love_version: ['11.4', '11.3', '11.2', '0.10.2', '0.9.2', '0.8.0']
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: nhartland/love-build@dev
       id: love-build
       with:
@@ -45,7 +45,7 @@ jobs:
       matrix:
         love_version: ['11.4', '11.3', '11.2', '0.10.2', '0.9.2', '0.8.0']
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: nhartland/love-build@dev
       id: love-build
       with:

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         love_version: ['11.4', '11.3', '11.2', '0.10.2', '0.9.2', '0.8.0']
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: nhartland/love-build@master
       id: love-build
       with:
@@ -45,7 +45,7 @@ jobs:
       matrix:
         love_version: ['11.4', '11.3', '11.2', '0.10.2', '0.9.2', '0.8.0']
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: nhartland/love-build@master
       id: love-build
       with:

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ repository, use the following job steps:
 
 ```yaml
 steps:
-- uses: actions/checkout@v2
+- uses: actions/checkout@v3
 # Build the applications
 - uses: nhartland/love-build@master
   with:
@@ -38,7 +38,7 @@ steps:
 
 ```yaml
 steps:
-- uses: actions/checkout@v2
+- uses: actions/checkout@v3
 - uses: nhartland/love-build@master
   with:
     app_name: 'hello_world'
@@ -76,7 +76,7 @@ following steps:
 
 ```yaml
 steps:
-- uses: actions/checkout@v2
+- uses: actions/checkout@v3
 - uses: nhartland/love-build@master
   id: love-build
   with:


### PR DESCRIPTION

Fixes warning message "build
Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/checkout@v2"